### PR TITLE
Fix failing stem pair update test

### DIFF
--- a/tests/test_bulge_graph_updater.py
+++ b/tests/test_bulge_graph_updater.py
@@ -238,10 +238,13 @@ def test_bulge_graph_update(case):
     action = case["mod_action"]
 
     if action == "insert_pair":
-        left, right = sorted(inserted)
+        # SequenceMatcher can sometimes return more than two indices or
+        # duplicate indices when aligning repetitive regions.  Use the
+        # outermost indices to determine the inserted base pair.
+        left, right = min(inserted), max(inserted)
         BulgeGraphUpdater.insert_stem_pair(bg, node, left, right)
     elif action == "delete_pair":
-        left, right = sorted(deleted)
+        left, right = min(deleted), max(deleted)
         BulgeGraphUpdater.delete_stem_pair(bg, node, left, right)
     elif action == "insert":
         BulgeGraphUpdater.insert_loop_base(bg, node, inserted[0])


### PR DESCRIPTION
## Summary
- make stem pair tests robust to extra indices from SequenceMatcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688008225fd08326b85cd930be8b6686