### PR TITLE
Add fraction-based modification sampling

### DIFF
--- a/core/dataset_generator.py
+++ b/core/dataset_generator.py
@@ -114,7 +114,7 @@ class DatasetGenerator:
         anchor_graph = self.bulge_parser.parse_structure(anchor_struct)
         
         # Step 3: Sample modifications and generate positive
-        sampled_mods = self.modification_engine.sample_modifications()
+        sampled_mods = self.modification_engine.sample_modifications(anchor_graph)
         pos_seq, pos_struct, mod_counts = self.modification_engine.apply_modifications(
             anchor_seq, anchor_struct, anchor_graph, sampled_mods
         )


### PR DESCRIPTION
## Summary
- add optional `f_*_indels_*` parameters for modification probabilities
- validate that number-based and fraction-based options aren't mixed
- sample modification counts from anchor structures when using fractions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809a28279483269aafb337f0916838