### PR TITLE
Add structure length totals to output

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -99,6 +99,11 @@ class RnaTriplet:
     iloop_modifications: int
     bulge_modifications: int
     mloop_modifications: int
+    total_len_stems: int
+    total_len_hloops: int
+    total_len_iloops: int
+    total_len_bulges: int
+    total_len_mloops: int
 
 
 @dataclass

--- a/utils/output_handler.py
+++ b/utils/output_handler.py
@@ -98,7 +98,9 @@ class OutputHandler:
                 'triplet_id', 'anchor_seq', 'anchor_structure',
                 'positive_seq', 'positive_structure', 'negative_seq', 'negative_structure',
                 'total_modifications', 'stem_modifications', 'hloop_modifications',
-                'iloop_modifications', 'bulge_modifications', 'mloop_modifications'
+                'iloop_modifications', 'bulge_modifications', 'mloop_modifications',
+                'total_len_stems', 'total_len_hloops', 'total_len_iloops',
+                'total_len_bulges', 'total_len_mloops'
             ]
             
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -118,7 +120,12 @@ class OutputHandler:
                     'hloop_modifications': triplet.hloop_modifications,
                     'iloop_modifications': triplet.iloop_modifications,
                     'bulge_modifications': triplet.bulge_modifications,
-                    'mloop_modifications': triplet.mloop_modifications
+                    'mloop_modifications': triplet.mloop_modifications,
+                    'total_len_stems': triplet.total_len_stems,
+                    'total_len_hloops': triplet.total_len_hloops,
+                    'total_len_iloops': triplet.total_len_iloops,
+                    'total_len_bulges': triplet.total_len_bulges,
+                    'total_len_mloops': triplet.total_len_mloops
                 })
     
     def _save_metadata(self, metadata, file_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend `RnaTriplet` with fields for total nucleotide lengths of stems, hairpins, internal loops, bulges and multiloops
- compute these totals while generating each triplet
- include the totals as columns when saving the dataset CSV

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880adee98dc832685c9a19aff9da0ed