### PR TITLE
Track insert/delete actions per structure

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,8 +3,8 @@ Core package for the RNA triplet generator.
 """
 
 from .models import (
-    RnaTriplet, DatasetMetadata, BulgeGraph, GraphNode, 
-    ModificationCounts, SampledModifications, NodeType, 
+    RnaTriplet, DatasetMetadata, BulgeGraph, GraphNode,
+    ModificationCounts, SampledModifications, ActionCounts, NodeType,
     ModificationType, classify_node
 )
 from .rna_generator import RnaGenerator, BulgeGraphParser
@@ -15,7 +15,7 @@ from .dataset_generator import DatasetGenerator
 
 __all__ = [
     'RnaTriplet', 'DatasetMetadata', 'BulgeGraph', 'GraphNode',
-    'ModificationCounts', 'SampledModifications', 'NodeType',
+    'ModificationCounts', 'SampledModifications', 'ActionCounts', 'NodeType',
     'ModificationType', 'classify_node', 'RnaGenerator', 
     'BulgeGraphParser', 'ModificationEngine', 'BulgeGraphUpdater',
     'NegativeSampleGenerator', 'AppendingEngine', 'DatasetGenerator'

--- a/core/dataset_generator.py
+++ b/core/dataset_generator.py
@@ -159,7 +159,7 @@ class DatasetGenerator:
         
         # Step 3: Sample modifications and generate positive
         sampled_mods = self.modification_engine.sample_modifications(anchor_graph)
-        pos_seq, pos_struct, mod_counts = self.modification_engine.apply_modifications(
+        pos_seq, pos_struct, mod_counts, action_counts = self.modification_engine.apply_modifications(
             anchor_seq, anchor_struct, anchor_graph, sampled_mods
         )
         
@@ -190,7 +190,19 @@ class DatasetGenerator:
             total_len_hloops=hloop_len,
             total_len_iloops=iloop_len,
             total_len_bulges=bulge_len,
-            total_len_mloops=mloop_len
+            total_len_mloops=mloop_len,
+            stem_insertions=action_counts.stem_insertions,
+            stem_deletions=action_counts.stem_deletions,
+            hloop_insertions=action_counts.hloop_insertions,
+            hloop_deletions=action_counts.hloop_deletions,
+            iloop_insertions=action_counts.iloop_insertions,
+            iloop_deletions=action_counts.iloop_deletions,
+            bulge_insertions=action_counts.bulge_insertions,
+            bulge_deletions=action_counts.bulge_deletions,
+            mloop_insertions=action_counts.mloop_insertions,
+            mloop_deletions=action_counts.mloop_deletions,
+            total_insertions=action_counts.total_insertions,
+            total_deletions=action_counts.total_deletions
         )
     
     def _generate_anchor(self) -> tuple[str, str]:

--- a/core/models.py
+++ b/core/models.py
@@ -84,6 +84,23 @@ class SampledModifications:
 
 
 @dataclass
+class ActionCounts:
+    """Tracks counts of insertion and deletion actions by structure type."""
+    total_insertions: int = 0
+    total_deletions: int = 0
+    stem_insertions: int = 0
+    stem_deletions: int = 0
+    hloop_insertions: int = 0
+    hloop_deletions: int = 0
+    iloop_insertions: int = 0
+    iloop_deletions: int = 0
+    bulge_insertions: int = 0
+    bulge_deletions: int = 0
+    mloop_insertions: int = 0
+    mloop_deletions: int = 0
+
+
+@dataclass
 class RnaTriplet:
     """Represents a complete RNA triplet with anchor, positive, and negative samples."""
     triplet_id: int
@@ -104,6 +121,18 @@ class RnaTriplet:
     total_len_iloops: int
     total_len_bulges: int
     total_len_mloops: int
+    stem_insertions: int
+    stem_deletions: int
+    hloop_insertions: int
+    hloop_deletions: int
+    iloop_insertions: int
+    iloop_deletions: int
+    bulge_insertions: int
+    bulge_deletions: int
+    mloop_insertions: int
+    mloop_deletions: int
+    total_insertions: int
+    total_deletions: int
 
 
 @dataclass

--- a/utils/output_handler.py
+++ b/utils/output_handler.py
@@ -100,7 +100,13 @@ class OutputHandler:
                 'total_modifications', 'stem_modifications', 'hloop_modifications',
                 'iloop_modifications', 'bulge_modifications', 'mloop_modifications',
                 'total_len_stems', 'total_len_hloops', 'total_len_iloops',
-                'total_len_bulges', 'total_len_mloops'
+                'total_len_bulges', 'total_len_mloops',
+                'stem_insertions', 'stem_deletions',
+                'hloop_insertions', 'hloop_deletions',
+                'iloop_insertions', 'iloop_deletions',
+                'bulge_insertions', 'bulge_deletions',
+                'mloop_insertions', 'mloop_deletions',
+                'total_insertions', 'total_deletions'
             ]
             
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -125,7 +131,19 @@ class OutputHandler:
                     'total_len_hloops': triplet.total_len_hloops,
                     'total_len_iloops': triplet.total_len_iloops,
                     'total_len_bulges': triplet.total_len_bulges,
-                    'total_len_mloops': triplet.total_len_mloops
+                    'total_len_mloops': triplet.total_len_mloops,
+                    'stem_insertions': triplet.stem_insertions,
+                    'stem_deletions': triplet.stem_deletions,
+                    'hloop_insertions': triplet.hloop_insertions,
+                    'hloop_deletions': triplet.hloop_deletions,
+                    'iloop_insertions': triplet.iloop_insertions,
+                    'iloop_deletions': triplet.iloop_deletions,
+                    'bulge_insertions': triplet.bulge_insertions,
+                    'bulge_deletions': triplet.bulge_deletions,
+                    'mloop_insertions': triplet.mloop_insertions,
+                    'mloop_deletions': triplet.mloop_deletions,
+                    'total_insertions': triplet.total_insertions,
+                    'total_deletions': triplet.total_deletions
                 })
     
     def _save_metadata(self, metadata, file_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend `RnaTriplet` with insertion/deletion counts
- add `ActionCounts` dataclass and track actions in `ModificationEngine`
- return action counts to `DatasetGenerator`
- export new fields to CSV via `OutputHandler`
- expose `ActionCounts` in `core.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b1a32f1083269a89664d7df773e3